### PR TITLE
Adds Connections to Leaderboards through Win Pop Ups

### DIFF
--- a/lib/connections.dart
+++ b/lib/connections.dart
@@ -70,6 +70,13 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
             },
             child: const Text('OK'),
           ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              Navigator.pushNamed(context, '/connectionsleaderboard'); //Navigate to Leaderboard
+            },
+            child: const Text('View Leaderboard'),
+          ),
         ],
       ),
     );

--- a/lib/wordladder_frontend.dart
+++ b/lib/wordladder_frontend.dart
@@ -50,7 +50,14 @@ class _WordLadderGameApp extends State<WordLadderGame> {
                     resetGame();
                   },
                   child: Text("Play Again"),
-                )
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    Navigator.pushNamed(context, '/wordladderleaderboard'); //Navigate to leaderboard
+                  },
+                  child: const Text('View Leaderboard'),
+                ),
               ],
             ),
           );


### PR DESCRIPTION
Due to Solve the Puzzle Task not being completed, creating a win pop up and connecting leaderboard for letterquest couldn't be done. Should be relatively straightforward, and will be done as soon as the rest of the letterquest game is completed. This does fulfill it for Word Ladder and Connections.