### PR TITLE
Minor Bug Fix: Negative Score in Word Ladder Game

### DIFF
--- a/lib/wordladder_frontend.dart
+++ b/lib/wordladder_frontend.dart
@@ -33,10 +33,12 @@ class _WordLadderGameApp extends State<WordLadderGame> {
 
   void _startTimer() {
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
-      if (secondsElapsed < 999 && score > 0) {
+      if (secondsElapsed < 999) {
         setState(() {
           secondsElapsed++;
-          score = (score - 10).clamp(0, 10000);
+          if (score > 0) {
+            score = (score - 10).clamp(0, 10000);
+          }
         });
       } else {
         _timer.cancel();


### PR DESCRIPTION
Fixed word ladder so that the score cannot go below zero. Also fixed another, previously unknown issue where the timer stopped when the score reached 0.