### PR TITLE
Adds Test Entries to Leaderboard

### DIFF
--- a/lib/data/seed_connections.dart
+++ b/lib/data/seed_connections.dart
@@ -1,5 +1,4 @@
 import 'package:team_19/models/connections_model.dart'; 
-import '/db/databasehelper.dart';
 
 final connection1 = Connnection(
   id: 1,

--- a/lib/data/seed_letterquest.dart
+++ b/lib/data/seed_letterquest.dart
@@ -1,5 +1,4 @@
 import 'package:team_19/models/letterquest_model.dart'; 
-import '/db/databasehelper.dart';
 
 final letterquest1 = Letterquest(id: 1, phrase: 'UNDER THE WEATHER', hint: 'Sick');
 final letterquest2 = Letterquest(id: 2, phrase: 'SPILL THE BEANS', hint: 'Reveal');

--- a/lib/data/seed_wordladder.dart
+++ b/lib/data/seed_wordladder.dart
@@ -1,5 +1,4 @@
 import 'package:team_19/models/wordladder_model.dart'; 
-import '/db/databasehelper.dart';
 
 final wordLadder1 = Wordladder(id: 1, wordList: ['basket', 'ball', 'game', 'show', 'case']);
 final wordLadder2 = Wordladder(id: 2, wordList: ['fire', 'smoke', 'alarm', 'clock', 'time']);

--- a/lib/db/databasehelper.dart
+++ b/lib/db/databasehelper.dart
@@ -68,6 +68,7 @@ class DatabaseHelper {
             wordladderTimes TEXT NOT NULL
           );
         """);
+        await DatabaseHelper.seedTestUsersIfEmpty();
       },
       version: _version,
     );
@@ -184,4 +185,82 @@ class DatabaseHelper {
     final data = await db.query("Users", where: 'name = ?', whereArgs: [name]);
     return data.isNotEmpty ? User.fromJson(data.first) : null;
   }
+
+  static Future<void> seedTestUsersIfEmpty() async {
+    final db = await _getDB();
+    final List<Map<String, dynamic>> users = await db.query("Users");
+
+      if (users.isEmpty) {
+        List<User> testUsers = [
+          User(
+            name: "Jonnathan M.",
+            connectionsScores: {1: 80},
+            connectionsTimes: {1: 90},
+            letterquestScores: {1: 100},
+            letterquestTimes: {1: 90},
+            wordladderScores: {1: 100},
+            wordladderTimes: {1: 90},
+          ),
+          User(
+            name: "Jonnathan B.",
+            connectionsScores: {1: 80},
+            connectionsTimes: {1: 120},
+            letterquestScores: {1: 80},
+            letterquestTimes: {1: 120},
+            wordladderScores: {1: 80},
+            wordladderTimes: {1: 120},
+          ),
+          User(
+            name: "Beau",
+            connectionsScores: {1: 75},
+            connectionsTimes: {1: 123},
+            letterquestScores: {1: 75},
+            letterquestTimes: {1: 123},
+            wordladderScores: {1: 75},
+            wordladderTimes: {1: 123},
+          ),
+          User(
+            name: "Bryce",
+            connectionsScores: {1: 1},
+            connectionsTimes: {1: 999},
+            letterquestScores: {1: 1},
+            letterquestTimes: {1: 999},
+            wordladderScores: {1: 1},
+            wordladderTimes: {1: 999},
+          ),
+          User(
+            name: "Skylur",
+            connectionsScores: {1: 50},
+            connectionsTimes: {1: 110},
+            letterquestScores: {1: 50},
+            letterquestTimes: {1: 110},
+            wordladderScores: {1: 50},
+            wordladderTimes: {1: 110},
+          ),
+          User(
+            name: "Alex",
+            connectionsScores: {1: 80},
+            connectionsTimes: {1: 100},
+            letterquestScores: {1: 80},
+            letterquestTimes: {1: 100},
+            wordladderScores: {1: 80},
+            wordladderTimes: {1: 100},
+          ),
+          User(
+            name: "Steve",
+            connectionsScores: {1: 80},
+            connectionsTimes: {1: 95},
+            letterquestScores: {1: 80},
+            letterquestTimes: {1: 95},
+            wordladderScores: {1: 80},
+            wordladderTimes: {1: 95},
+          ),
+      ];
+
+      for (final user in testUsers) {
+        await addUser(user);
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
Should theoretically add test cases to database which should be called to the leaderboard. Bryce's fix wasn't pushed when I worked on this, so this may need to be iterated on if not done correctly, as I had no way to test these changes, but I am generally confident this should work. Also cleans up a useless line of code in each seed data file.