### PR TITLE
Check for Username on All Pages

### DIFF
--- a/lib/connections.dart
+++ b/lib/connections.dart
@@ -2,13 +2,9 @@ import 'package:flutter/material.dart';
 import 'dart:math';
 import 'dart:async';
 
-void main() {
-  runApp(const ConnectionsGameScreen());
-}
-
-
 class ConnectionsGameScreen extends StatefulWidget {
-  const ConnectionsGameScreen({super.key});
+  final String userName;
+  const ConnectionsGameScreen({super.key, required this.userName});
 
   @override
   _ConnectionsGameScreenState createState() => _ConnectionsGameScreenState();

--- a/lib/game_selector.dart
+++ b/lib/game_selector.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:team_19/connections.dart';
+import 'package:team_19/letterquest.dart';
+import 'package:team_19/wordladder_frontend.dart';
 
 class GameSelectionScreen extends StatelessWidget {
+  final String userName;
+  GameSelectionScreen({required this.userName});
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -47,21 +52,21 @@ class GameSelectionScreen extends StatelessWidget {
                     context,
                     'Connections',
                     'assets/images/connections_logo.png',
-                    () => Navigator.pushNamed(context, '/connections'),
+                    () => Navigator.push(context, MaterialPageRoute(builder: (context) => ConnectionsGameScreen(userName: userName))),
                   ),
                   const SizedBox(width: 16),
                   _buildGameTile(
                     context,
                     'LetterQuest',
                     'assets/images/letterquest_logo.png',
-                    () => Navigator.pushNamed(context, '/letterquest'),
+                    () => Navigator.push(context, MaterialPageRoute(builder: (context) => LetterQuestGame(userName: userName))),
                   ),
                   const SizedBox(width: 16),
                   _buildGameTile(
                     context,
                     'Word Ladder',
                     'assets/images/wordladder_logo.png',
-                    () => Navigator.pushNamed(context, '/wordladder'),
+                    () => Navigator.push(context, MaterialPageRoute(builder: (context) => WordLadderGame(userName: userName))),
                   ),
                 ],
               ),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:team_19/db/databasehelper.dart';
+import 'package:team_19/game_selector.dart';
 import 'package:team_19/models/user_model.dart';
 
 class HomePage extends StatefulWidget {
@@ -90,7 +91,9 @@ class _HomePageState extends State<HomePage> {
             ),
             ElevatedButton(
               onPressed: () {
-                 Navigator.pushNamed(context, '/gameselection');
+                 Navigator.push(context, MaterialPageRoute(builder: (context) => GameSelectionScreen(userName: userName!),
+              ),
+            );
               },
               style: ElevatedButton.styleFrom(
                 padding: EdgeInsets.symmetric(horizontal: 40, vertical: 15),

--- a/lib/letterquest.dart
+++ b/lib/letterquest.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'keyboard_ui.dart';
 
 class LetterQuestGame extends StatefulWidget {
+  final String userName;
+  const LetterQuestGame({super.key, required this.userName});
   @override
   _LetterQuestGameState createState() => _LetterQuestGameState();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,10 +4,6 @@ import 'package:sqflite_common_ffi_web/sqflite_ffi_web.dart';
 import 'package:flutter/foundation.dart';
 import 'package:team_19/home_page.dart';
 import 'package:team_19/leaderboard_selector.dart';
-import 'game_selector.dart'; 
-import 'connections.dart';
-import 'letterquest.dart';
-import 'wordladder_frontend.dart';
 import 'letterquest_leaderboard_page.dart';
 import 'wordladder_leaderboard_page.dart';
 import 'connections_leaderboard_page.dart';
@@ -33,11 +29,7 @@ class MyApp extends StatelessWidget {
       ),
       home: HomePage(), //Eventually, this needs to be changed to the home page 
       routes: {
-        '/gameselection': (context) => GameSelectionScreen(), 
         '/leaderboardselection': (context) => LeaderboardSelectionScreen(),
-        '/connections': (context) => ConnectionsGameScreen(),
-        '/letterquest': (context) => LetterQuestGame(),
-        '/wordladder': (context) => WordLadderGame(),
         '/letterquestleaderboard': (context) => LetterQuestLeaderboard(),
         '/wordladderleaderboard' : (context) => WordLadderLeaderboard(), 
         '/connectionsleaderboard' : (context) => ConnectionsLeaderboard(), 

--- a/lib/wordladder_frontend.dart
+++ b/lib/wordladder_frontend.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 
 class WordLadderGame extends StatefulWidget {
+  final String userName;
+  const WordLadderGame({super.key, required this.userName});
   @override
   _WordLadderGameApp createState() => _WordLadderGameApp();
 }


### PR DESCRIPTION
Changed the routes to all game related pages so that the username entered now travels along to those pages. Removed the routes listed in main.dart as they did not work with the new Navigator required for those pages. 