### PR TITLE
Adds Level Selector to All 3 Games

### DIFF
--- a/lib/connections.dart
+++ b/lib/connections.dart
@@ -27,48 +27,12 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
 
   int _currentLevelId = 1;
 
+  bool hasSelectedLevel = false;
+
   @override
   void initState() {
     super.initState();
-    _loadLevel();
-    _startTimer();
-  }
-
-  Future<void> _loadLevel() async {
-    try {
-      final Connnection? level = await DatabaseHelper.fetchConnectionById(_currentLevelId);
-
-      if (level != null) {
-        setState(() {
-          categories = level.categories;
-          _currentLevelId++;
-          words = categories.values.expand((e) => e).toList();
-          words.shuffle(Random());
-        });
-      } else {
-        setState(() {
-          categories = {'': ['']};
-        });
-      }
-    } catch (e) {
-      setState(() {
-        categories = {'': ['']};
-      });
-      print('Error loading Scattergories level: $e');
-    }
-  }
-
-  Future<void> _loadNextLevel() async {
-    setState(() {
-      isGameOver = false;
-      selectedWords = [];
-      foundCategories = {};
-      attemptsLeft = 4;
-      secondsElapsed = 0;
-      solvedWords = {};
-      _startTimer();
-    });
-    await _loadLevel();
+    _showLevelSelector();
   }
 
   void _startTimer() {
@@ -103,7 +67,7 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
     User? winner = await DatabaseHelper.fetchUserByName(widget.userName);
 
     if (winner != null) {
-      int actualID = _currentLevelId - 1;
+      int actualID = _currentLevelId;
 
       bool savedNew = false;
 
@@ -329,6 +293,14 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
             ),
           ),
           IconButton(
+            icon: Icon(Icons.grid_view),
+            tooltip: 'Select Level',
+            onPressed: () {
+              _gameTimer?.cancel();
+              _showLevelSelector();
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.help_outline),
             tooltip: 'How to Play',
             onPressed: () {
@@ -396,11 +368,6 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
               ),
             ),
             const SizedBox(height: 20),
-            if (isGameOver)
-              ElevatedButton(
-                onPressed: _loadNextLevel,
-                child: const Text('Next Level'),
-              ),
           ],
         ),
       ),
@@ -435,5 +402,96 @@ class _ConnectionsGameScreenState extends State<ConnectionsGameScreen> {
         ),
       ),
     );
+  }
+
+   void _showLevelSelector() async {
+    List<Connnection> allLevels = await DatabaseHelper.fetchAllConnections();
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          title: const Text(
+            'Select a Level',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 350,
+            child: Scrollbar(
+              thumbVisibility: true,
+              child: ListView.separated(
+                itemCount: allLevels.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  int levelId = allLevels[index].id;
+                  bool isSelected = _currentLevelId == levelId;
+
+                  return ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    tileColor: isSelected ? Colors.deepPurple[100] : Colors.grey[100],
+                    title: Text(
+                      'Level $levelId',
+                      style: TextStyle(
+                        fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                        color: isSelected ? Colors.deepPurple : Colors.black,
+                      ),
+                    ),
+                    onTap: () async {
+                      Navigator.of(context).pop();
+                      setState(() {
+                        _currentLevelId = levelId;
+                        hasSelectedLevel = true;
+                      });
+                      await _loadLevelById(levelId);
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+          actionsAlignment: MainAxisAlignment.center,
+          actions: hasSelectedLevel
+            ? [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text(
+                    'Cancel',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ]
+            : [],
+        );
+      },
+    );
+  }
+
+  Future<void> _loadLevelById(int id) async {
+    try {
+      final Connnection? level = await DatabaseHelper.fetchConnectionById(id);
+      if (level != null) {
+        setState(() {
+          categories = level.categories;
+          isGameOver = false;
+          selectedWords = [];
+          foundCategories = {};
+          attemptsLeft = 4;
+          secondsElapsed = 0;
+          solvedWords = {};
+          words = categories.values.expand((e) => e).toList();
+          words.shuffle(Random());
+          _startTimer();
+        });
+      }
+    } catch (e) {
+      print('Error loading level $id: $e');
+    }
   }
 }

--- a/lib/letterquest.dart
+++ b/lib/letterquest.dart
@@ -29,13 +29,14 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
 
   int _currentLevelId = 1;
 
+  bool hasSelectedLevel = false;
+
   late ElevatedButton submitButton;
 
   @override
   void initState() {
     super.initState();
-    _loadLevel();
-    _startTimer();
+    _showLevelSelector();
   }
 
   @override
@@ -43,47 +44,6 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
     _timer.cancel();
     _phraseController.dispose(); 
     super.dispose();
-  }
-
-  Future<void> _loadLevel() async {
-    try {
-    final Letterquest? level = await DatabaseHelper.fetchLetterquestById(_currentLevelId);
-
-    if (level != null) {
-      setState(() {
-        phrase = level.phrase.toUpperCase(); // Force uppercase
-        hint = level.hint;
-        _currentLevelId++; // Move to next level for next time
-      });
-    } else {
-      setState(() {
-        phrase = '';
-        hint = 'No more puzzles available.';
-      });
-    }
-  } catch (e) {
-    setState(() {
-      phrase = '';
-      hint = 'Error loading puzzle.';
-    });
-    print('Error loading Letterquest level: $e');
-  }
-  }
-
-  Future<void> _loadNextLevel() async {
-    setState(() {
-      isGameOver = false; 
-      phrase = "";
-      hint = "";
-      guessedLetters = {};
-      isSolvingPhrase = false;
-      fullPhraseAttempt = "";
-      incorrectAttempts = 0;
-      secondsElapsed = 0; 
-      showSubmitButton = true;
-      _startTimer();     
-    });
-    await _loadLevel();        
   }
 
   void _startTimer() {
@@ -126,6 +86,14 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
                 ),
               ),
             ],
+          ),
+          IconButton(
+            icon: Icon(Icons.grid_view),
+            tooltip: 'Select Level',
+            onPressed: () {
+              _timer.cancel();
+              _showLevelSelector();
+            },
           ),
           IconButton(
             icon: Icon(Icons.help_outline),
@@ -187,18 +155,15 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
               onEnter: () {},
               onDelete: () {},
             ),
-          if (isGameOver)
-            ElevatedButton(
-              onPressed: _loadNextLevel,
-              child: Text('Next Level'),
-            )
         ],
       ),
     );
   }
 
   Widget _buildPhraseDisplay() {
-    return Wrap(
+  return Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+    child: Wrap(
       alignment: WrapAlignment.center,
       spacing: 4.0,
       runSpacing: 8.0,
@@ -216,8 +181,9 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
           ),
         );
       }).toList(),
-    );
-  }
+    ),
+  );
+}
 
   Widget _buildSolveButton() {
     return ElevatedButton(
@@ -311,7 +277,7 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
     User? winner = await DatabaseHelper.fetchUserByName(widget.userName);
 
     if (winner != null) {
-      int actualID = _currentLevelId - 1;
+      int actualID = _currentLevelId;
 
       Map<int, int> winnerTimes = winner.letterquestTimes;
       
@@ -358,5 +324,97 @@ class _LetterQuestGameState extends State<LetterQuestGame> {
         ],
       ),
     );
+  }
+
+  void _showLevelSelector() async {
+    List<Letterquest> allLevels = await DatabaseHelper.fetchAllLetterquests();
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          title: const Text(
+            'Select a Level',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 350,
+            child: Scrollbar(
+              thumbVisibility: true,
+              child: ListView.separated(
+                itemCount: allLevels.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  int levelId = allLevels[index].id;
+                  bool isSelected = _currentLevelId == levelId;
+
+                  return ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    tileColor: isSelected ? Colors.deepPurple[100] : Colors.grey[100],
+                    title: Text(
+                      'Level $levelId',
+                      style: TextStyle(
+                        fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                        color: isSelected ? Colors.deepPurple : Colors.black,
+                      ),
+                    ),
+                    onTap: () async {
+                      Navigator.of(context).pop();
+                      setState(() {
+                        _currentLevelId = levelId;
+                        hasSelectedLevel = true;
+                      });
+                      await _loadLevelById(levelId);
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+          actionsAlignment: MainAxisAlignment.center,
+          actions: hasSelectedLevel
+            ? [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text(
+                    'Cancel',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ]
+            : [],
+        );
+      },
+    );
+  }
+
+  Future<void> _loadLevelById(int id) async {
+    try {
+      final Letterquest? level = await DatabaseHelper.fetchLetterquestById(id);
+      if (level != null) {
+        setState(() {
+          phrase = level.phrase.toUpperCase();
+          hint = level.hint;
+          guessedLetters.clear();
+          isGameOver = false;
+          isSolvingPhrase = false;
+          fullPhraseAttempt = "";
+          incorrectAttempts = 0;
+          secondsElapsed = 0; 
+          showSubmitButton = true;
+          _currentLevelId = level.id;
+          _startTimer();
+        });
+      }
+    } catch (e) {
+      print('Error loading level $id: $e');
+    }
   }
 }

--- a/lib/wordladder_frontend.dart
+++ b/lib/wordladder_frontend.dart
@@ -12,14 +12,12 @@ class WordLadderGame extends StatefulWidget {
 }
 
 class _WordLadderGameApp extends State<WordLadderGame> {
-  //final List<String> wordList = ['BASKET', 'BALL', 'GAME', 'SHOW', 'CASE'];
   List<String> wordList = [""];
   late List<String> currentWordLadder;
   int score = 10000;
   int incorrectGuesses = 0;
   int currentIndex = 1;
   TextEditingController wordController = TextEditingController();
-  bool isGameOver = false;
 
   // Timer-related
   late Timer _timer;
@@ -27,55 +25,19 @@ class _WordLadderGameApp extends State<WordLadderGame> {
 
   int _currentLevelId = 1;
 
+  bool hasSelectedLevel = false;
+
   @override
   void initState() {
     super.initState();
     currentWordLadder = hideWords(wordList);
-    _loadLevel();
-    _startTimer();
+    _showLevelSelector();
   }
 
   @override
   void dispose() {
     _timer.cancel();
     super.dispose();
-  }
-
-  Future<void> _loadLevel() async {
-    try {
-    final Wordladder? level = await DatabaseHelper.fetchWordladderById(_currentLevelId);
-
-    if (level != null) {
-      setState(() {
-        wordList = level.wordList; 
-        currentWordLadder = hideWords(wordList); 
-        _currentLevelId++; // Move to next level for next time
-      });
-    } else {
-      setState(() {
-        wordList = [""];
-        currentWordLadder = [""];
-      });
-    }
-  } catch (e) {
-    setState(() {
-      wordList = [""];
-      currentWordLadder = [""];
-    });
-    print('Error loading Wordladder level: $e');
-  }
-  }
-
-  Future<void> _loadNextLevel() async {
-    setState(() {
-      isGameOver = false; 
-      score = 10000;
-      incorrectGuesses = 0;
-      currentIndex = 1;
-      secondsElapsed = 0; 
-    });
-    await _loadLevel(); 
-    _startTimer();       
   }
 
   void _startTimer() {
@@ -123,17 +85,6 @@ class _WordLadderGameApp extends State<WordLadderGame> {
     }
   }
 
-  void resetGame() {
-    setState(() {
-      currentIndex = 1;
-      incorrectGuesses = 0;
-      score = 10000;
-      secondsElapsed = 0;
-      currentWordLadder = hideWords(wordList);
-      _startTimer();
-    });
-  }
-
   final TextStyle appBarTitleStyle = TextStyle(
       color: Colors.white,
       fontSize: 22,
@@ -164,6 +115,14 @@ class _WordLadderGameApp extends State<WordLadderGame> {
                 style: appBarTitleStyle,
               ),
             ),
+          ),
+          IconButton(
+            icon: Icon(Icons.grid_view),
+            tooltip: 'Select Level',
+            onPressed: () {
+              _timer.cancel();
+              _showLevelSelector();
+            },
           ),
           IconButton(
             icon: Icon(Icons.help_outline),
@@ -228,11 +187,6 @@ class _WordLadderGameApp extends State<WordLadderGame> {
             ElevatedButton(onPressed: checkGuess, child: Text("Submit Guess")),
             SizedBox(height: 10),
             Text("Incorrect Guesses: $incorrectGuesses"),
-            if (isGameOver)
-              ElevatedButton(
-                onPressed: _loadNextLevel,
-                child: Text('Next Level'),
-              )
           ],
         ),
       ),
@@ -242,15 +196,11 @@ class _WordLadderGameApp extends State<WordLadderGame> {
   void _showWinPopup() async
   {
     _timer.cancel();
-    setState(() {
-      isGameOver = true;
-    });
-
 
     User? winner = await DatabaseHelper.fetchUserByName(widget.userName);
 
     if (winner != null) {
-      int actualID = _currentLevelId - 1;
+      int actualID = _currentLevelId;
 
       bool savedNew = false;
 
@@ -307,7 +257,6 @@ class _WordLadderGameApp extends State<WordLadderGame> {
           TextButton(
             onPressed: () {
               Navigator.pop(context);
-              //resetGame();
             },
             child: Text("OK"),
           ),
@@ -321,5 +270,93 @@ class _WordLadderGameApp extends State<WordLadderGame> {
         ],
       ),
     );
+  }
+
+  void _showLevelSelector() async {
+    List<Wordladder> allLevels = await DatabaseHelper.fetchAllWordladders();
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          title: const Text(
+            'Select a Level',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 350,
+            child: Scrollbar(
+              thumbVisibility: true,
+              child: ListView.separated(
+                itemCount: allLevels.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  int levelId = allLevels[index].id;
+                  bool isSelected = _currentLevelId == levelId;
+
+                  return ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    tileColor: isSelected ? Colors.deepPurple[100] : Colors.grey[100],
+                    title: Text(
+                      'Level $levelId',
+                      style: TextStyle(
+                        fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                        color: isSelected ? Colors.deepPurple : Colors.black,
+                      ),
+                    ),
+                    onTap: () async {
+                      Navigator.of(context).pop();
+                      setState(() {
+                        _currentLevelId = levelId;
+                        hasSelectedLevel = true;
+                      });
+                      await _loadLevelById(levelId);
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+          actionsAlignment: MainAxisAlignment.center,
+          actions: hasSelectedLevel
+            ? [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text(
+                    'Cancel',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
+              ]
+            : [],
+        );
+      },
+    );
+  }
+
+  Future<void> _loadLevelById(int id) async {
+    try {
+      final Wordladder? level = await DatabaseHelper.fetchWordladderById(id);
+      if (level != null) {
+        setState(() {
+          wordList = level.wordList;
+          currentWordLadder = hideWords(wordList);
+          currentIndex = 1;
+          score = 10000;
+          incorrectGuesses = 0;
+          secondsElapsed = 0;
+          _startTimer();
+        });
+      }
+    } catch (e) {
+      print('Error loading level $id: $e');
+    }
   }
 }


### PR DESCRIPTION
Adds a level selector to all 3 games that allows the user to pick which level they want to play initially, and adds an icon button in the appbar to access this selector at anytime. Removed all functionality for Next Level Button, and tweaked database collection functions in the win pop up functions. Cleared most useless comments or redundancies in code in Letterquest, WordLadderFrontEnd, and Connections files.